### PR TITLE
Add TCP daemon support.

### DIFF
--- a/server.js
+++ b/server.js
@@ -29,17 +29,36 @@ app.get('/', function(req, res) {
   res.send(indexData);
 });
 
+console.log(process.env.DOCKER_HOST)
+
+  if(process.env.DOCKER_HOST) {
+     try {
+	   dh = process.env.DOCKER_HOST.split(":");
+	   var docker_host = dh[0]; 
+	   var docker_port = dh[1];
+     } 
+	 catch (err) {
+	   console.log(err.stack)
+     }
+	}
   var wss = new WebSocketServer({server: server});
   
   app.get('/apis/*', function(req, response) {
       var path = req.params[0];
       var jsonData={};
+      var options = {
+		  path: ('/' + path),
+		  method: 'GET'
+	  }
 
-        var options = {
-        socketPath: "/var/run/docker.sock",
-        path: ('/' + path),
-        method: 'GET'
-      };
+    if(docker_host) {
+        options.host = docker_host;
+		    options.port = docker_port;
+	  }
+	  else {
+		    options.socketPath = '/var/run/docker.sock';
+    }
+
     var req = http.request(options, (res) => {
       var data = '';
       res.on('data', (chunk) => {


### PR DESCRIPTION
Been playing with a full swarm mode cluster using dind and want to be able to run visualizer at the host level but point it at a swarm manager using TCP daemon (on same network) rather than just `/var/run/docker.sock`. Can now pass in `-e DOCKER_HOST` in the same usual format <host>:<port> and visualizer will use that.

Usage now allows: `docker run -itd -p 8080:8080 -e HOST=localhost --net <my_swarm_network> -e DOCKER_HOST=<swarm_manager_host>:<swarm_manager_port> manomarks/visualizer`
