### PR TITLE
Remove width to fit for more nodes into row

### DIFF
--- a/src/main.less
+++ b/src/main.less
@@ -35,5 +35,4 @@ html,body{
 }
 #app {
   margin: 0 auto;
-  width: 60%;
 }


### PR DESCRIPTION
Removing the `width: 60%` from the app tag helps to fit more nodes into one row.

Before:

![bildschirmfoto 2016-07-31 um 17 04 49](https://cloud.githubusercontent.com/assets/207759/17277341/fce4bc32-5740-11e6-9b46-cfcca9bae753.png)

After:

![bildschirmfoto 2016-07-31 um 17 04 39](https://cloud.githubusercontent.com/assets/207759/17277338/f0934034-5740-11e6-95ac-329e786d994e.png)
