### PR TITLE
aarch64 Support

### DIFF
--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,4 +1,33 @@
-FROM frozeneye/aarch64-nodejs:latest
+FROM aarch64/debian:jessie
+
+ENV NPM_CONFIG_LOGLEVEL info
+ENV NODE_VERSION "6.3.1"
+ENV ARCH arm64
+# gpg keys listed at https://github.com/nodejs/node
+RUN set -ex \
+  && for key in \
+    9554F04D7259F04124DE6B476D5A82AC7E37093B \
+    94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
+    0034A06D9D9B0064CE8ADF6BF1747F4AD2306D93 \
+    FD3A5288F042B6850C66B31F09FE44734EB7990E \
+    71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
+    DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
+    B9AE9905FFD7803F25714661B63B535A4C206CA9 \
+    C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
+  ; do \
+    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+  done \
+  && buildDeps='xz-utils curl' \
+  && set -x \
+  && apt-get update && apt-get install -y $buildDeps --no-install-recommends \
+  && rm -rf /var/lib/apt/lists/* \
+  && curl -SLOk "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \
+  && curl -SLOk "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
+  && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
+  && grep " node-v$NODE_VERSION-linux-$ARCH.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
+  && tar -xJf "node-v$NODE_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 \
+  && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
+  && apt-get purge -y --auto-remove $buildDeps
 
 WORKDIR /app
 

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,33 +1,4 @@
-FROM aarch64/debian:jessie
-
-ENV NPM_CONFIG_LOGLEVEL info
-ENV NODE_VERSION "6.3.1"
-ENV ARCH arm64
-# gpg keys listed at https://github.com/nodejs/node
-RUN set -ex \
-  && for key in \
-    9554F04D7259F04124DE6B476D5A82AC7E37093B \
-    94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
-    0034A06D9D9B0064CE8ADF6BF1747F4AD2306D93 \
-    FD3A5288F042B6850C66B31F09FE44734EB7990E \
-    71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
-    DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
-    B9AE9905FFD7803F25714661B63B535A4C206CA9 \
-    C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
-  ; do \
-    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
-  done \
-  && buildDeps='xz-utils curl' \
-  && set -x \
-  && apt-get update && apt-get install -y $buildDeps --no-install-recommends \
-  && rm -rf /var/lib/apt/lists/* \
-  && curl -SLOk "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \
-  && curl -SLOk "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
-  && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
-  && grep " node-v$NODE_VERSION-linux-$ARCH.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
-  && tar -xJf "node-v$NODE_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 \
-  && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
-  && apt-get purge -y --auto-remove $buildDeps
+FROM aarch64/node:4.6.0-slim
 
 WORKDIR /app
 

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,0 +1,29 @@
+FROM frozeneye/aarch64-nodejs:latest
+
+WORKDIR /app
+
+# Only run npm install if these files change.
+ADD ./package.json /app/package.json
+
+# Install dependencies
+RUN npm install --unsafe-perm=true
+
+# Add the rest of the sources
+ADD . /app
+
+# Build the app
+RUN npm run dist
+
+# Default host is localhost. This is for same-origin policies.
+ENV HOST "localhost"
+
+# Number of milliseconds between polling requests. Default is 200.
+ENV MS 200
+
+#Default port to expose.
+ENV PORT 8080
+EXPOSE 8080
+
+RUN npm install
+
+CMD ["npm","start"]


### PR DESCRIPTION
I just slightly modified the arm Dockerfile to make it run on my Pine64 card cluster.
Just changed to the frozeneye nodejs repository, so in essence it works exactly as arm arch.

To run it on dedicated hardware I build the container as:
```
docker $(docker-machine config pine64-1) build -f Dockerfile.aarch64 -t visualizer-aarch64 .
```
And I run it as:
```
docker $(docker-machine config pine64-1) run -it -d --privileged -p 8080:8080 -e HOST=pine64-1 -v /var/run/docker.sock:/var/run/docker.sock --name visualizer-aarch64_box visualizer-aarch64
```
Note the "--privileged" parameter, needed to overpass permissions problems

Hope it's helpful for anyone besides me 