### PR TITLE
Add Dockerfile for Windows nanoserver

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -1,0 +1,22 @@
+FROM stefanscherer/node-windows:4.6.1-nano
+
+WORKDIR /app
+
+# Only run npm install if these files change.
+ADD ./package.json /app/package.json
+
+# Install dependencies
+RUN npm install --unsafe-perm=true
+
+# Add the rest of the sources
+ADD . /app
+
+# Build the app
+RUN npm run dist
+
+# Number of milliseconds between polling requests. Default is 200.
+ENV MS 200
+
+EXPOSE 8080
+
+CMD ["npm.cmd","start"]

--- a/README.md
+++ b/README.md
@@ -48,7 +48,29 @@ If you would like to build the image from source run the following command:
 $ docker build -f Dockerfile.arm -t visualizer-arm:latest .
 ```
 
+## Running on Windows
 
+[@StefanScherer](https://github.com/StefanScherer) has pushed an image to the
+Docker Hub as `stefanscherer/visualizer-windows:latest` it will run the code
+in a Windows nanoserver container.
+
+If you would like to build the image from source run the following command:
+
+```
+$ docker build -f Dockerfile.windows -t visualizer-windows:latest .
+```
+
+On Windows you cannot use `-v` to bind mount the named pipe into the container.
+Your Docker engine has to listen to a TCP port, eg. 2375 and you have to
+set the `DOCKER_HOST` environment variable running the container.
+
+```
+$ip=(Get-NetIPAddress -AddressFamily IPv4 `
+   | Where-Object -FilterScript { $_.InterfaceAlias -Eq "vEthernet (HNS Internal NIC)" } `
+   ).IPAddress
+
+docker run -d -p 8080:8080 -e DOCKER_HOST=${ip}:2375 --name=visualizer stefanscherer/visualizer-windows
+```
 
 TODO:
 * Take out or fix how dist works


### PR DESCRIPTION
It is time to have the Docker Swarm Visualizer for Windows. Here is a Dockerfile to build the Visualizer in a Windows nanoserver.

To run it the Docker engine should additionally listen on port 2375, then run it from a PowerShell terminal

```powershell
$ip=(Get-NetIPAddress -AddressFamily IPv4 `
   | Where-Object -FilterScript { $_.InterfaceAlias -Eq "vEthernet (HNS Internal NIC)" } `
   ).IPAddress

docker run -d -p 8080:8080 -e DOCKER_HOST=${ip}:2375 --name=visualizer stefanscherer/visualizer-windows
```