### PR TITLE
Fix memory calculation to GByte

### DIFF
--- a/src/data-provider.js
+++ b/src/data-provider.js
@@ -176,7 +176,7 @@ updateNodes = (nodes) => {
           if(name.length>0) {
             currentnode.Description.Hostname = name ;
             currentnode.name = name+" <br/> "+ node.Spec.Role+
-            " <br/>"+(currentnode.Description.Resources.MemoryBytes/1000000000).toFixed(0)+"G RAM";
+            " <br/>"+(currentnode.Description.Resources.MemoryBytes/1024/1024/1024).toFixed(0)+"G RAM";
           }
           updateNode(currentnode, node.state, node.Spec);
         }


### PR DESCRIPTION
It seems this matters only if you are running swarm nodes with much more memory, but the calculation from real bytes to display the "G RAM" seems wrong. It should divide by 1024 * 1024 * 1024 instead of 1000000000 to have Giga Bytes.

Using a packet.net ARMv8 machine with nominal 128GByte RAM shows 135 before the change:

Before:
![bildschirmfoto 2016-11-28 um 22 31 48](https://cloud.githubusercontent.com/assets/207759/20703120/d0900374-b61a-11e6-8bbe-54714984a7af.png)

Afterwards it shows 126 which seems correct as not all of the memory is available.

After:
<img width="1352" alt="bildschirmfoto 2016-11-29 um 09 59 36" src="https://cloud.githubusercontent.com/assets/207759/20703125/d6980078-b61a-11e6-9866-f95bee379766.png">

