### PR TITLE
Initial migration of Dockerfile and Dockerfile.aarch64 to Alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #Latest version of node tested on.
-FROM node:4.1.2-slim
+FROM node:4.7-alpine
 
 WORKDIR /app
 

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -46,23 +46,22 @@ RUN adduser -D -u 1000 node \
  WORKDIR /app
 
 # Only run npm install if these files change.
- ADD ./package.json /app/package.json
+ADD ./package.json /app/package.json
 
 # Install dependencies
- RUN npm install --unsafe-perm=true
+RUN npm install --unsafe-perm=true
 
 # Add the rest of the sources
- ADD . /app
+ADD . /app
 
 # Build the app
- RUN npm run dist
+RUN npm run dist
 
 # Number of milliseconds between polling requests. Default is 200.
- ENV MS 200
+ENV MS 200
 
- EXPOSE 8080
+EXPOSE 8080
 
- RUN npm install
+RUN npm install
 
- CMD ["npm","start"]
-# CMD ["/bin/ash"]
+CMD ["npm","start"]

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,24 +1,68 @@
-FROM aarch64/node:4.6.0-slim
+FROM aarch64/alpine
 
-WORKDIR /app
+ENV NPM_CONFIG_LOGLEVEL info
+ENV NODE_VERSION 4.7.2
+
+RUN adduser -D -u 1000 node \
+    && apk add --no-cache \
+        libstdc++ \
+    && apk add --no-cache --virtual .build-deps \
+        binutils-gold \
+        curl \
+        g++ \
+        gcc \
+        gnupg \
+        libgcc \
+        linux-headers \
+        make \
+        python \
+  && for key in \
+    9554F04D7259F04124DE6B476D5A82AC7E37093B \
+    94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
+    0034A06D9D9B0064CE8ADF6BF1747F4AD2306D93 \
+    FD3A5288F042B6850C66B31F09FE44734EB7990E \
+    71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
+    DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
+    B9AE9905FFD7803F25714661B63B535A4C206CA9 \
+    C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
+  ; do \
+    gpg --keyserver pgp.mit.edu --recv-keys "$key"; \
+  done \
+    && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION.tar.xz" \
+    && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
+    && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
+    && grep " node-v$NODE_VERSION.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
+    && tar -xf "node-v$NODE_VERSION.tar.xz" \
+    && cd "node-v$NODE_VERSION" \
+    && ./configure \
+    && make -j$(getconf _NPROCESSORS_ONLN) \
+    && make install \
+    && apk del .build-deps \
+    && cd .. \
+    && rm -Rf "node-v$NODE_VERSION" \
+    && rm "node-v$NODE_VERSION.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt
+
+
+ WORKDIR /app
 
 # Only run npm install if these files change.
-ADD ./package.json /app/package.json
+ ADD ./package.json /app/package.json
 
 # Install dependencies
-RUN npm install --unsafe-perm=true
+ RUN npm install --unsafe-perm=true
 
 # Add the rest of the sources
-ADD . /app
+ ADD . /app
 
 # Build the app
-RUN npm run dist
+ RUN npm run dist
 
 # Number of milliseconds between polling requests. Default is 200.
-ENV MS 200
+ ENV MS 200
 
-EXPOSE 8080
+ EXPOSE 8080
 
-RUN npm install
+ RUN npm install
 
-CMD ["npm","start"]
+ CMD ["npm","start"]
+# CMD ["/bin/ash"]


### PR DESCRIPTION
One of the problems I've seen using this images, especially important on aarch64, is that even the Dockerfile is based on official node slim image,the result is pretty thick. So I tried to move base images from Debian to Alpine, and the space reduction seems pretty nice to me, close 50%

Dockerfile 159 MB vs prior 371 MB
Dockerfile.aarch64 166 MB vs prior 317 MB

Dockerfile.aarch64 modifications are based on official 4.7-alpine node image. I just changed pgp server to mit.edu one because it's more reliable